### PR TITLE
feat: export banners in import_output

### DIFF
--- a/src/blogtoblog/BlogToBlogImporter.ts
+++ b/src/blogtoblog/BlogToBlogImporter.ts
@@ -41,6 +41,16 @@ export default class BlogToBlogImporter extends PageImporter {
     });
   }
 
+  findBanners(element: Element, document: Document): any {
+    const banners = [];
+    element.querySelectorAll('main > div > table th').forEach((th) => {
+      if (th.innerHTML === 'Banner') {
+        banners.push(th.parentElement.parentElement.querySelector('a').textContent);
+      }
+    });
+    return banners.join(', ');
+  }
+
   buildRecommendedArticlesTable(element: Element, document: Document): void {
     element.querySelectorAll('main > div > h2').forEach((h2) => {
       if (h2.textContent.toLowerCase().startsWith('featured posts')) {
@@ -214,9 +224,9 @@ export default class BlogToBlogImporter extends PageImporter {
       for (let j = 0; j < clazz.length; j++) {
         const url = promoList[clazz[j]];
         if (url) {
-          // found a matching class name - replace with table embed
+          // found a matching class name - replace with table banner
           embed.replaceWith(DOM.createTable([
-            ['Embed'],
+            ['Banner'],
             [`<a href="${url}">${url}</a>`],
           ], document));
           return;
@@ -262,6 +272,7 @@ export default class BlogToBlogImporter extends PageImporter {
     // TODO: collect list of promotions and export in import_output
 
     this.renameBlocks(main, document);
+    const banners = this.findBanners(main, document);
     this.buildRecommendedArticlesTable(main, document);
     const meta = this.buildMetadataTable(head, main, document, entryParams);
 
@@ -282,6 +293,7 @@ export default class BlogToBlogImporter extends PageImporter {
       category: meta.category,
       date: meta.date,
       lang,
+      banners,
     });
 
     return [pir];

--- a/src/blogtoblog/import.ts
+++ b/src/blogtoblog/import.ts
@@ -41,7 +41,7 @@ async function getPromoList() {
 }
 
 
-const DATA_LIMIT = 20;
+const DATA_LIMIT = 10;
 
 async function getEntries() {
   const req = await fetch('https://main--business-website--adobe.hlx.page/drafts/alex/import/cmo-dx-content-to-migrate---official.json');
@@ -149,16 +149,17 @@ async function main() {
     blobHandler: blob,
     cache: '.cache/blogtoblog',
     skipAssetsUpload: true,
+    skipDocxConversion: true,
   });
 
-  let output = `source;file;lang;author;date;category;topics;tags;\n`;
+  let output = `source;file;lang;author;date;category;topics;tags;banners;\n`;
   await Utils.asyncForEach(entries, async (e) => {
     try {
       const resources = await importer.import(e.URL, { allEntries: entries, category: e.Category, tags: e['Article Tags'], promoList: promoListJSON });
 
       resources.forEach((entry) => {
         console.log(`${entry.source} -> ${entry.file}`);
-        output += `${entry.source};${entry.file};${entry.extra.lang};${entry.extra.author};${entry.extra.date};${entry.extra.category};${entry.extra.topics};${entry.extra.tags};\n`;
+        output += `${entry.source};${entry.file};${entry.extra.lang};${entry.extra.author};${entry.extra.date};${entry.extra.category};${entry.extra.topics};${entry.extra.tags};${entry.extra.banners}\n`;
       });
       await handler.put('importer_output.csv', output);
     } catch(error) {


### PR DESCRIPTION
- `convertOldStylePromotions` creates "banner" tables instead of "embed" tables
- if a post contains "banner" tables, a list of banner URLs is outputted in the CSV importer output 