### PR TITLE
refactor: meta description

### DIFF
--- a/src/blogtoblog/BlogToBlogImporter.ts
+++ b/src/blogtoblog/BlogToBlogImporter.ts
@@ -115,17 +115,19 @@ export default class BlogToBlogImporter extends PageImporter {
       } else {
         // check if heading follows h1 in "article header" area
         const h1 = main.querySelector('h1');
-        const h1Sibling = h1.nextElementSibling;
-        if (h1Sibling.nodeName.startsWith('H')) {
-          const descRow = document.createElement('tr');
-          table.append(descRow);
-          const descTitle = document.createElement('td');
-          descTitle.textContent = 'Description';
-          descRow.append(descTitle);
-          const descData = document.createElement('td');
-          descData.textContent = h1Sibling.textContent;
-          descRow.append(descData);
-          h1Sibling.remove();
+        if (h1) {
+          const h1Sibling = h1.nextElementSibling;
+          if (h1Sibling.nodeName.startsWith('H')) {
+            const descRow = document.createElement('tr');
+            table.append(descRow);
+            const descTitle = document.createElement('td');
+            descTitle.textContent = 'Description';
+            descRow.append(descTitle);
+            const descData = document.createElement('td');
+            descData.textContent = h1Sibling.textContent;
+            descRow.append(descData);
+            h1Sibling.remove();
+          }
         }
       }
     }

--- a/src/blogtoblog/BlogToBlogImporter.ts
+++ b/src/blogtoblog/BlogToBlogImporter.ts
@@ -130,8 +130,6 @@ export default class BlogToBlogImporter extends PageImporter {
       }
     }
 
-
-
     const [authorStr, dateStr] = Array
       .from(main.querySelectorAll('main > div:nth-child(3) > p'))
       .map(p => p.textContent);

--- a/src/blogtoblog/BlogToBlogImporter.ts
+++ b/src/blogtoblog/BlogToBlogImporter.ts
@@ -112,8 +112,25 @@ export default class BlogToBlogImporter extends PageImporter {
         const descData = document.createElement('td');
         descData.textContent = metaDesc;
         descRow.append(descData);
+      } else {
+        // check if heading follows h1 in "article header" area
+        const h1 = main.querySelector('h1');
+        const h1Sibling = h1.nextElementSibling;
+        if (h1Sibling.nodeName.startsWith('H')) {
+          const descRow = document.createElement('tr');
+          table.append(descRow);
+          const descTitle = document.createElement('td');
+          descTitle.textContent = 'Description';
+          descRow.append(descTitle);
+          const descData = document.createElement('td');
+          descData.textContent = h1Sibling.textContent;
+          descRow.append(descData);
+          h1Sibling.remove();
+        }
       }
     }
+
+
 
     const [authorStr, dateStr] = Array
       .from(main.querySelectorAll('main > div:nth-child(3) > p'))

--- a/src/blogtoblog/import.ts
+++ b/src/blogtoblog/import.ts
@@ -43,6 +43,15 @@ async function getPromoList() {
 
 const DATA_LIMIT = 200000;
 
+const [argMin, argMax] = process.argv.slice(2);
+
+function sectionData(data, min, max) {
+  min = min ? Number(min) : 0;
+  max = max ? Number(max) : data.length;
+  const section = data.slice(min, max);
+  return section;
+}
+
 async function getEntries() {
   const req = await fetch('https://main--business-website--adobe.hlx.page/drafts/alex/import/cmo-dx-content-to-migrate---official.json');
   const res = [];
@@ -143,7 +152,8 @@ async function main() {
   //   },
   // ];
 
-  const entries = await getEntries();
+  const allEntries = await getEntries();
+  const entries = sectionData(allEntries, argMin, argMax);
 
   // entries.forEach((e) => {
   //   e.URL = e.URL.replace('https://blog.adobe.com', 'https://master--theblog--adobe.hlx.page');
@@ -154,7 +164,7 @@ async function main() {
     blobHandler: blob,
     cache: '.cache/blogtoblog',
     skipAssetsUpload: true,
-    // skipDocxConversion: true,
+    skipDocxConversion: true,
   });
 
   let output = `source;file;lang;author;date;category;topics;tags;banners;\n`;

--- a/src/blogtoblog/import.ts
+++ b/src/blogtoblog/import.ts
@@ -46,7 +46,8 @@ const DATA_LIMIT = 200000;
 const [argMin, argMax] = process.argv.slice(2);
 
 function sectionData(data, min, max) {
-  min = min ? Number(min) : 0;
+  if (!min) { return data; }
+  min = Number(min);
   max = max ? Number(max) : data.length;
   const section = data.slice(min, max);
   return section;

--- a/test/blogtoblog/BlogToBlogImport.spec.ts
+++ b/test/blogtoblog/BlogToBlogImport.spec.ts
@@ -95,21 +95,21 @@ describe('BlogToBlogImporter#buildMetadataTable tests', () => {
 
   it('build metadata table, constructed description omitted', () => {
     test(
-      `<meta name="description" content="${shortp}"></head>`,
+      `<meta name="description" content="${shortp}">`,
       `<meta name="description" content="${shortp}">`,
       `<main>${div}${div}<div><p>By Katie Sexton</p><p>Posted on 09-09-2019</p></div>${pdiv}<div><p>Topics: Alpha, Beta, Gamma,</p><p>Products: Delta, Echo, Foxtrot,</p></div></main>`,
       `<main>${div}${div}${pdiv}<table><tr><th>Metadata</th></tr><tr><td>Author</td><td>Katie Sexton</td></tr><tr><td>Publication Date</td><td>09-09-2019</td></tr><tr><td>Category</td><td>news</td></tr><tr><td>Tags</td><td>Creative Cloud, News</td></tr><tr><td>Topics</td><td>Alpha, Beta, Gamma, Delta, Echo, Foxtrot</td></tr></table></main>`);
   });
   it('build metadata table, missing date', () => {
     test(
-      `<meta name="description" content="${shortp}"></head>`,
+      `<meta name="description" content="${shortp}">`,
       `<meta name="description" content="${shortp}">`,
       `<main>${div}${div}<div><p>By Katie Sexton</p></div>${pdiv}<div><p>Topics: Alpha, Beta, Gamma,</p><p>Products: Delta, Echo, Foxtrot,</p></div></main>`,
       `<main>${div}${div}${pdiv}<table><tr><th>Metadata</th></tr><tr><td>Author</td><td>Katie Sexton</td></tr><tr><td>Category</td><td>news</td></tr><tr><td>Tags</td><td>Creative Cloud, News</td></tr><tr><td>Topics</td><td>Alpha, Beta, Gamma, Delta, Echo, Foxtrot</td></tr></table></main>`);
   });
   it('build metadata table, missing category', () => {
     test(
-      `<meta name="description" content="${shortp}"></head>`,
+      `<meta name="description" content="${shortp}">`,
       `<meta name="description" content="${shortp}">`,
       `<main>${div}${div}<div><p>By Katie Sexton</p></div>${pdiv}<div><p>Topics: Alpha, Beta, Gamma,</p><p>Products: Delta, Echo, Foxtrot,</p></div></main>`,
       `<main>${div}${div}${pdiv}<table><tr><th>Metadata</th></tr><tr><td>Author</td><td>Katie Sexton</td></tr><tr><td>Category</td><td>news</td></tr><tr><td>Tags</td><td>Creative Cloud, News</td></tr><tr><td>Topics</td><td>Alpha, Beta, Gamma, Delta, Echo, Foxtrot</td></tr></table></main>`);


### PR DESCRIPTION
capture old-style meta descriptions (heading immediately following `h1` within the "article header' block)